### PR TITLE
Fix typo annotation for `LifeSpanManager.__call__` method

### DIFF
--- a/fastapi_lifespan_manager/lifespan_manager.py
+++ b/fastapi_lifespan_manager/lifespan_manager.py
@@ -25,7 +25,7 @@ from fastapi import FastAPI
 from fastapi.concurrency import contextmanager_in_threadpool
 from typing_extensions import Self
 
-from .types import AnyContextManager, AnyState, RawLifespan, State, TApp
+from .types import AnyContextManager, AnyState, RawLifespan, TApp
 
 
 def _maybe_call(call: Callable[..., AnyContextManager], app: Optional[TApp]) -> AnyContextManager:
@@ -90,7 +90,7 @@ class LifespanManager(Generic[TApp]):
         self.lifespans.extend(other.lifespans)
 
     @asynccontextmanager
-    async def __call__(self, app: TApp) -> AsyncIterator[Optional[State]]:
+    async def __call__(self, app: TApp) -> AsyncIterator[AnyState]:
         async with AsyncExitStack() as astack:
             state: Optional[Dict[str, Any]] = None
 

--- a/tests/test_mypy.py
+++ b/tests/test_mypy.py
@@ -19,6 +19,20 @@ def _normalize_check(code: str = "", success: bool = True) -> str:
     return code + "Success: no issues found in 1 source file\n" if success else ""
 
 
+def test_pass_manager_to_app():
+    output = _run_mypy(
+        """
+    from fastapi import FastAPI
+    from fastapi_lifespan_manager import LifespanManager
+
+    manager = LifespanManager()
+    app = FastAPI(lifespan=manager)
+    """,
+    )
+
+    assert output == _normalize_check()
+
+
 def test_manager_no_args():
     output = _run_mypy(
         """


### PR DESCRIPTION
Fixes #121 